### PR TITLE
Add Clay logging, check for token count before processing any text

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const clayLog = require('clay-log');
+
+let log = clayLog.init({
+  name: 'data-analysis'
+});
+
+module.exports = log;

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,9 +1,23 @@
 'use strict';
 
-const clayLog = require('clay-log');
+const clayLog = require('clay-log'),
+  _defaults = require('lodash/defaults');
 
-let log = clayLog.init({
-  name: 'data-analysis'
-});
+/**
+ * Call this function in specific files to get a logging
+ * instance specific to that file. Handy for adding
+ * the filename or any other file specific meta information
+ *
+ * @param  {Object} meta
+ * @return {Function}
+ */
+function setup(meta) {
+  meta = _defaults({}, meta, {file: 'File not specified! Please declare a file'});
 
-module.exports = log;
+  return clayLog.init({
+    name: 'data-analysis',
+    meta: meta
+  });
+}
+
+module.exports = setup;

--- a/lib/modules/big-query.js
+++ b/lib/modules/big-query.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const BigQuery = require('@google-cloud/bigquery'),
-  _find = require('lodash/find');
+  _find = require('lodash/find'),
+  log = require('../log.js');
 
 
 /**
@@ -15,7 +16,7 @@ function createDataset(datasetName, bigquery) {
     .then((results) => {
       const dataset = results[0];
 
-      console.log(`BigQuery dataset ${dataset.id} created.`);
+      log('info', `BigQuery dataset ${dataset.id} created.`);
       return dataset;;
     });
 }
@@ -32,7 +33,7 @@ function createTable(dataset, tableId, options) {
     .then((results) => {
       const table = results[0];
 
-      console.log(`BigQuery table ${tableId} created.`);
+      log('info', `BigQuery table ${table.id} created.`);
       return table;
     });
 }
@@ -87,15 +88,15 @@ function insert(data) {
 
   return createDatasetifDoesntExist(dataset, bigquery)
     .then((results) => {
-      return createTableIfDoesntExist(results, table, schema)
+      return createTableIfDoesntExist(results, table, schema);
     })
     .then((table) => {
-      return table.insert(ops)
+      return table.insert(ops);
     })
     .catch((err) => {
       // An API error or partial failure occurred.
       if (err.name === 'PartialFailureError') {
-        console.log(`Partial Failure Error occured: ${err.errors[0]}`);
+        log('warn', `Partial Failure occured: ${err.errors[0]}`);
       }
     });
 

--- a/lib/modules/big-query.js
+++ b/lib/modules/big-query.js
@@ -2,7 +2,7 @@
 
 const BigQuery = require('@google-cloud/bigquery'),
   _find = require('lodash/find'),
-  log = require('../log.js');
+  log = require('../log.js')({ file: __filename });
 
 
 /**

--- a/lib/modules/classify-content.js
+++ b/lib/modules/classify-content.js
@@ -2,36 +2,47 @@
 
 const LanguageServiceClient = require('@google-cloud/language').v1beta2.LanguageServiceClient,
   language = new LanguageServiceClient(),
-  bigQuery = require('./big-query');
+  bigQuery = require('./big-query'),
+  log = require('../log.js');
+
 
 /**
  * Classify content based off of the `analyze` property and insert to BigQuery
 
  * @param {Object} data
+ * @returns {Object} data
  */
 function analyze(data) {
   const document = {
-    content: data.ops[0].analyze,
-    type: 'PLAIN_TEXT',
-  };
+      content: data.ops[0].analyze,
+      type: 'PLAIN_TEXT',
+    },
+    wordCount = document.content.match(/(\w+)/g);
 
-  language
-    .classifyText({document: document})
-    .then(results => {
-      const classification = results[0];
-      
-      classification.categories.forEach(category => {
-        data.ops[0].category = category.name;
-        data.ops[0].categoryConfidence = category.confidence;
+  // At least 20 tokens (words) must be supplied to a document
+  if (wordCount.length > 20) {
+    language
+      .classifyText({document: document})
+      .then(results => {
+        const classification = results[0];
+
+        classification.categories.forEach(category => {
+          data.ops[0].category = category.name;
+          data.ops[0].categoryConfidence = category.confidence;
+        });
+
+        data.ops[0].analyze = data.ops[0].analyze.toString(); // Store as string to match the data type
+
+        return bigQuery.insert(data);
+      })
+      .catch(err => {
+        log('warn', err);
       });
-      
-      data.ops[0].analyze = data.ops[0].analyze.toString(); // Store as string to match the data type
+  } else {
+    data.ops[0].analyze = data.ops[0].analyze.toString();
 
-      return bigQuery.insert(data);
-    })
-    .catch(err => {
-      console.error('ERROR:', err);
-    });
+    return bigQuery.insert(data);
+  }
 }
 
 module.exports = analyze;

--- a/lib/modules/classify-content.js
+++ b/lib/modules/classify-content.js
@@ -3,7 +3,7 @@
 const LanguageServiceClient = require('@google-cloud/language').v1beta2.LanguageServiceClient,
   language = new LanguageServiceClient(),
   bigQuery = require('./big-query'),
-  log = require('../log.js');
+  log = require('../log.js')({ file: __filename });
 
 
 /**

--- a/lib/modules/sentiment-analysis.js
+++ b/lib/modules/sentiment-analysis.js
@@ -8,27 +8,36 @@ const LanguageServiceClient = require('@google-cloud/language').LanguageServiceC
  * Analyze the sentiment of content based off of the `analyze` property and insert to BigQuery
 
  * @param {Object} data
+ * @returns {Object} data
  */
 function analyze(data) {
   const document = {
-    content: data.ops[0].analyze,
-    type: 'PLAIN_TEXT',
-  };
+      content: data.ops[0].analyze,
+      type: 'PLAIN_TEXT',
+    },
+    wordCount = document.content.match(/(\w+)/g);
 
-  language
-    .analyzeSentiment({document: document})
-    .then(results => {
-      const sentiment = results[0].documentSentiment;
+  // At least 20 tokens (words) must be supplied to a document
+  if (wordCount.length > 20) {
+    language
+      .analyzeSentiment({document: document})
+      .then(results => {
+        const sentiment = results[0].documentSentiment;
 
-      data.ops[0].analyze = data.ops[0].analyze.toString();
-      data.ops[0].sentimentScore = sentiment.score;
-      data.ops[0].sentimentMagnitude = sentiment.magnitude;
+        data.ops[0].analyze = data.ops[0].analyze.toString();
+        data.ops[0].sentimentScore = sentiment.score;
+        data.ops[0].sentimentMagnitude = sentiment.magnitude;
 
-      return bigQuery.insert(data);
-    })
-    .catch(err => {
-      console.error('ERROR:', err);
-    });
+        return bigQuery.insert(data);
+      })
+      .catch(err => {
+        log('warn', err);
+      });
+  } else {
+    data.ops[0].analyze = data.ops[0].analyze.toString();
+
+    return bigQuery.insert(data);
+  }
 }
 
 module.exports = analyze;

--- a/lib/modules/sentiment-analysis.js
+++ b/lib/modules/sentiment-analysis.js
@@ -2,7 +2,8 @@
 
 const LanguageServiceClient = require('@google-cloud/language').LanguageServiceClient,
   language = new LanguageServiceClient(),
-  bigQuery = require('./big-query');
+  bigQuery = require('./big-query'),
+  log = require('../log.js')({ file: __filename });
 
 /**
  * Analyze the sentiment of content based off of the `analyze` property and insert to BigQuery

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "data-analysis",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -414,6 +414,25 @@
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
+    "clay-log": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clay-log/-/clay-log-1.2.1.tgz",
+      "integrity": "sha1-XJnLr8dc2ECL1CzpRuF4al/ZOkk=",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "pino": "4.10.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -453,7 +472,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -461,8 +479,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "colour": {
       "version": "0.7.1",
@@ -888,6 +905,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
     },
+    "fast-json-parse": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -898,6 +920,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-safe-stringify": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz",
+      "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw=="
     },
     "figures": {
       "version": "2.0.0",
@@ -937,6 +964,11 @@
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
+    },
+    "flatstr": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.5.tgz",
+      "integrity": "sha1-W0UbCMvUji6sVKK74L9GFlqhS+M="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -2608,6 +2640,48 @@
         "pinkie": "2.0.4"
       }
     },
+    "pino": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-4.10.3.tgz",
+      "integrity": "sha512-IKXK0dcFQYITgOJBEvy1RCI5gUz+VVERXMhIvk5Ie+k9zzrbwXDs38M3H6JhoCHR58exyNpNcEKBrW4JC2P0pg==",
+      "requires": {
+        "chalk": "2.3.0",
+        "fast-json-parse": "1.0.3",
+        "fast-safe-stringify": "1.2.3",
+        "flatstr": "1.0.5",
+        "pump": "2.0.0",
+        "quick-format-unescaped": "1.1.2",
+        "split2": "2.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
@@ -2661,6 +2735,15 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "pump": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.0.tgz",
+      "integrity": "sha512-6MYypjOvtiXhBSTOD0Zs5eNjCGfnqi5mPsCsW+dgKTxrZzQMZQNpBo3XRkLx7id753f3EeyHLBqzqqUymIolgw==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -2670,6 +2753,14 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+    },
+    "quick-format-unescaped": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-1.1.2.tgz",
+      "integrity": "sha1-DKWB3jF0vs7yWsPC6JVjQjgdtpg=",
+      "requires": {
+        "fast-safe-stringify": "1.2.3"
+      }
     },
     "readable-stream": {
       "version": "2.3.3",
@@ -2868,6 +2959,14 @@
       "requires": {
         "async": "2.6.0",
         "is-stream-ended": "0.1.3"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "2.0.3"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@google-cloud/language": "^1.0.0",
     "JSONStream": "^1.3.2",
     "chai": "^4.1.2",
+    "clay-log": "^1.2.1",
     "elasticsearch": "^13.3.1",
     "elasticsearch-scroll-stream": "^1.1.3",
     "highland": "^2.11.1",


### PR DESCRIPTION
This PR:

* Adds Clay logging to non-cli modules
* Checks token count before processing any text that goes into BigQuery

Next PR:

* Addition of a document module (article data insert to BQ) that allows us to completely deprecate Mastermind's BigQuery task and this original repo which was based off of it: https://github.com/nymag/big-query-importer